### PR TITLE
Ask about installing latest NR version as a stack

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -64,6 +64,11 @@ call npm install --production --no-fund --no-audit --silent
 cd ..
 copy app\node_modules\@flowforge\flowforge\etc\flowforge.yml etc
 
+choice /M "Do you want to install latest Node-RED version as a Stack?"
+if %ERRORLEVEL% EQU 1 (
+    bin\ff-install-stack.bat 3.0.2
+)
+
 echo **************************************************************
 echo * Installed FlowForge                                        *
 echo * Start with bin\flowforge.bat

--- a/install.bat
+++ b/install.bat
@@ -64,10 +64,11 @@ call npm install --production --no-fund --no-audit --silent
 cd ..
 copy app\node_modules\@flowforge\flowforge\etc\flowforge.yml etc
 
-choice /M "Do you want to install latest Node-RED version as a Stack?"
-if %ERRORLEVEL% EQU 1 (
-    bin\ff-install-stack.bat 3.0.2
-)
+echo **************************************************************
+echo * Installing lastest Node-RED as a stack                     *
+echo **************************************************************
+bin\ff-install-stack.bat latest
+
 
 echo **************************************************************
 echo * Installed FlowForge                                        *

--- a/install.sh
+++ b/install.sh
@@ -179,6 +179,16 @@ if [ ! -f etc/flowforge.yml ]; then
   cp app/node_modules/@flowforge/flowforge/etc/flowforge.yml etc/flowforge.yml
 fi
 
+echo "**************************************************************"
+echo " Would you like to install latest Node-RED version as a Stack?"
+echo "**************************************************************"
+read -p "Y/n: " yn
+if [ -z "${yn}" ]; then
+  yn=Y
+fi
+if [[ "$yn" == "y" ]] || [[ "$yn" == "Y" ]]; then 
+  bin/ff-install-stack.sh 3.0.2
+fi
 
 if [[ "$OSTYPE" == linux* ]]; then
   if [ -x "$(command -v systemctl)" ]; then

--- a/install.sh
+++ b/install.sh
@@ -180,15 +180,10 @@ if [ ! -f etc/flowforge.yml ]; then
 fi
 
 echo "**************************************************************"
-echo " Would you like to install latest Node-RED version as a Stack?"
+echo " Installing lastest Node-RED as a stack"
 echo "**************************************************************"
-read -p "Y/n: " yn
-if [ -z "${yn}" ]; then
-  yn=Y
-fi
-if [[ "$yn" == "y" ]] || [[ "$yn" == "Y" ]]; then 
-  bin/ff-install-stack.sh 3.0.2
-fi
+bin/ff-install-stack.sh latest
+
 
 if [[ "$OSTYPE" == linux* ]]; then
   if [ -x "$(command -v systemctl)" ]; then


### PR DESCRIPTION
Lays the ground work to setup default stack at install time

At the moment it's hard coded to a version because the stack selector needs a semver number not just `latest` (open to allowing latest as an option if it makes things easier)