### PR TITLE
Remove 0.0.0.0 binding from mosquitto.conf

### DIFF
--- a/broker/mosquitto.conf
+++ b/broker/mosquitto.conf
@@ -1,9 +1,9 @@
 per_listener_settings false
 allow_anonymous false
 
-listener 1883 0.0.0.0
+listener 1883
 
-listener 1884 0.0.0.0
+listener 1884
 protocol websockets
 
 auth_plugin /opt/flowforge/broker/go-auth.so


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
This allows it to bind to IPv6 addresses

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [-] Upgrade instructions
    - [-] Configuration details
    - [-] Concepts

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

