### PR TITLE
Ensure default answer for "Current user" or "create FlowForge user"

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -206,6 +206,9 @@ if [[ "$OSTYPE" == linux* ]]; then
       echo "**************************************************************"
 
       read -p "Current/FlowForge (c/F): " cf
+      if [ -z "${cf}" ]; then
+        cf=F
+      fi
       if [[ "$cf" == "c" ]] || [[ "$cf" == "C" ]]; then
 
         FF_USER=`id -u -n`


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Install.sh script doesn't set a default answer for Current user or create FlowForge user

## Related Issue(s)

<!-- What issue does this PR relate to? -->
fixes #71

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [-] Upgrade instructions
    - [-] Configuration details
    - [-] Concepts

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

