### PR TITLE
Chore: Patching CI deprecation warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           TAG=$(echo $GITHUB_REF | awk -F '/' '{ print $3}' | sed 's/v//')
           echo $TAG
-          echo "::set-output name=tag::$TAG"
+          echo "{tag}={$TAG}" >> $GITHUB_OUTPUT
           mkdir "flowforge-installer"
           cp -R app bin broker etc var install.* LICENSE README.md "flowforge-installer"
           zip -r "flowforge-installer.zip" "flowforge-installer"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         
       - name: Build Zip
         id: build-zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,6 @@ jobs:
       - name: Build Zip
         id: build-zip
         run: |
-          TAG=$(echo $GITHUB_REF | awk -F '/' '{ print $3}' | sed 's/v//')
-          echo $TAG
-          echo "{tag}={$TAG}" >> $GITHUB_OUTPUT
           mkdir "flowforge-installer"
           cp -R app bin broker etc var install.* LICENSE README.md "flowforge-installer"
           zip -r "flowforge-installer.zip" "flowforge-installer"


### PR DESCRIPTION
## Description

I was reviewing this workflow as I wanted to do some changes for https://github.com/flowforge/flowforge/issues/1243, and I realized that some deprecation warnings appeared in [the previous execution](https://github.com/flowforge/flowforge/issues/1243).

So I decided to patch the warnings as follows:
- Bump the Nodejs version under the hood from Node.js 12 to 16 (143be7eb85ab7bf21a2a71845bab895d64c6ab2e), following [the official documentation](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)
- Replaced `set-output` for the new structure suggested in [the official documentation](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

## Related Issue(s)

Indirectly to https://github.com/flowforge/flowforge/issues/1243

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

